### PR TITLE
2 add experimental jetstream support

### DIFF
--- a/examples/durable/consumer.go
+++ b/examples/durable/consumer.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/syntropynet/data-layer-sdk/pkg/options"
+	"github.com/syntropynet/data-layer-sdk/pkg/service"
+)
+
+const (
+	SourceParam = "src"
+)
+
+type Publisher struct {
+	*service.Service
+}
+
+type MyMessage struct {
+	RequestWas []byte `json:"request"`
+}
+
+func New(o ...options.Option) (*Publisher, error) {
+	ret := &Publisher{
+		Service: &service.Service{},
+	}
+
+	ret.Service.Configure(o...)
+
+	return ret, nil
+}
+
+func (p *Publisher) Start() context.Context {
+	err := p.subscribe()
+	if err != nil {
+		p.Fail(err)
+		return p.Context
+	}
+
+	return p.Service.Start()
+}
+
+func (p *Publisher) subscribe() error {
+	src := options.Param(p.Options, SourceParam, "")
+	if src == "" {
+		return errors.New("source subject must not be empty")
+	}
+	if _, err := p.SubscribeTo(p.handleQuery, src); err != nil {
+		return err
+	}
+	p.PubNats.Flush()
+
+	return nil
+}
+
+func (p *Publisher) handleQuery(nmsg service.Message) {
+	fmt.Println("---", nmsg.Subject())
+	for k, v := range nmsg.Header() {
+		fmt.Printf("%s: %s\n", k, strings.Join(v, ", "))
+	}
+	fmt.Println()
+
+	fmt.Println(nmsg.Data())
+	fmt.Println()
+	fmt.Println()
+}

--- a/examples/durable/consumer.go
+++ b/examples/durable/consumer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/syntropynet/data-layer-sdk/pkg/options"
 	"github.com/syntropynet/data-layer-sdk/pkg/service"
@@ -27,7 +28,15 @@ func New(o ...options.Option) (*Publisher, error) {
 		Service: &service.Service{},
 	}
 
-	ret.Service.Configure(o...)
+	err := ret.Service.Configure(o...)
+	if err != nil {
+		return nil, err
+	}
+
+	err = ret.AddStream(10, 10240, time.Hour*24, options.Param(ret.Options, SourceParam, ""))
+	if err != nil {
+		return nil, err
+	}
 
 	return ret, nil
 }
@@ -50,10 +59,11 @@ func (p *Publisher) subscribe() error {
 	if _, err := p.SubscribeTo(p.handleQuery, src); err != nil {
 		return err
 	}
-	p.PubNats.Flush()
 
 	return nil
 }
+
+var cnt = 0
 
 func (p *Publisher) handleQuery(nmsg service.Message) {
 	fmt.Println("---", nmsg.Subject())
@@ -62,7 +72,7 @@ func (p *Publisher) handleQuery(nmsg service.Message) {
 	}
 	fmt.Println()
 
-	fmt.Println(nmsg.Data())
+	fmt.Println(string(nmsg.Data()))
 	fmt.Println()
 	fmt.Println()
 }

--- a/examples/durable/main.go
+++ b/examples/durable/main.go
@@ -7,16 +7,18 @@ import (
 	"os"
 	"os/signal"
 
+	_ "github.com/syntropynet/data-layer-sdk/pkg/dotenv"
+
 	"github.com/syntropynet/data-layer-sdk/pkg/options"
 	"github.com/syntropynet/data-layer-sdk/pkg/service"
 )
 
 func main() {
-	urls := flag.String("urls", "", "NATS urls")
+	urls := flag.String("urls", os.Getenv("NATS_URL"), "NATS urls")
 	source := flag.String("source", "syntropy_defi.price.single.ATOM", "Source Subject to stream from.")
-	creds := flag.String("nats-creds", "", "NATS credentials file")
-	nkey := flag.String("nats-nkey", "", "NATS NKey string")
-	jwt := flag.String("nats-jwt", "", "NATS JWT string")
+	creds := flag.String("nats-creds", os.Getenv("NATS_CREDS"), "NATS credentials file")
+	nkey := flag.String("nats-nkey", os.Getenv("NATS_NKEY"), "NATS NKey string")
+	jwt := flag.String("nats-jwt", os.Getenv("NATS_JWT"), "NATS JWT string")
 	verbose := flag.Bool("verbose", false, "Verbose logs")
 
 	flag.Parse()

--- a/examples/durable/main.go
+++ b/examples/durable/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"os"
+	"os/signal"
+
+	"github.com/syntropynet/data-layer-sdk/pkg/options"
+	"github.com/syntropynet/data-layer-sdk/pkg/service"
+)
+
+func main() {
+	urls := flag.String("urls", "", "NATS urls")
+	source := flag.String("source", "syntropy_defi.price.single.ATOM", "Source Subject to stream from.")
+	creds := flag.String("nats-creds", "", "NATS credentials file")
+	nkey := flag.String("nats-nkey", "", "NATS NKey string")
+	jwt := flag.String("nats-jwt", "", "NATS JWT string")
+	verbose := flag.Bool("verbose", false, "Verbose logs")
+
+	flag.Parse()
+
+	conn, err := options.MakeNats("Streaming consumer", *urls, *creds, *nkey, *jwt, "", "", "")
+	if err != nil {
+		log.Fatal("Failed creating NATS connection: ", err.Error())
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	var opts = []options.Option{
+		service.WithContext(ctx),
+		service.WithName("consume"),
+		service.WithNats(conn),
+		service.WithVerbose(*verbose),
+		service.WithParam(SourceParam, *source),
+	}
+
+	opts = append(
+		opts,
+		service.WithUserCreds(*creds),
+		service.WithNKeySeed(*nkey),
+	)
+
+	publisher, err := New(opts...)
+	if err != nil {
+		log.Fatal("Failed creating the consumer: ", err.Error())
+	}
+
+	pubCtx := publisher.Start()
+	defer publisher.Close()
+
+	select {
+	case <-ctx.Done():
+		log.Println("Shutdown")
+	case <-pubCtx.Done():
+		log.Println("Service stopped with cause: ", context.Cause(pubCtx).Error())
+	}
+}

--- a/examples/republish/main.go
+++ b/examples/republish/main.go
@@ -7,20 +7,22 @@ import (
 	"os"
 	"os/signal"
 
+	_ "github.com/syntropynet/data-layer-sdk/pkg/dotenv"
+
 	"github.com/syntropynet/data-layer-sdk/pkg/options"
 	"github.com/syntropynet/data-layer-sdk/pkg/service"
 )
 
 func main() {
-	urls := flag.String("urls", "", "NATS urls")
+	urls := flag.String("urls", os.Getenv("NATS_URL"), "NATS urls")
 	prefix := flag.String("prefix", "syntropy", "Subject prefix. The subject will be {prefix}.my_publisher")
 	source := flag.String("source", "syntropy.ethereum.tx", "Source Subject republish messages from.")
-	creds := flag.String("nats-creds", "", "NATS credentials file")
-	nkey := flag.String("nats-nkey", "", "NATS NKey string")
-	jwt := flag.String("nats-jwt", "", "NATS JWT string")
-	credsPub := flag.String("nats-creds-pub", "", "NATS credentials file for publishing")
-	nkeyPub := flag.String("nats-nkey-pub", "", "NATS NKey string for publishing")
-	jwtPub := flag.String("nats-jwt-pub", "", "NATS JWT string for publishing")
+	creds := flag.String("nats-creds", os.Getenv("NATS_CREDS"), "NATS credentials file")
+	nkey := flag.String("nats-nkey", os.Getenv("NATS_NKEY"), "NATS NKey string")
+	jwt := flag.String("nats-jwt", os.Getenv("NATS_JWT"), "NATS JWT string")
+	credsPub := flag.String("nats-creds-pub", os.Getenv("NATS_PUB_CREDS"), "NATS credentials file for publishing")
+	nkeyPub := flag.String("nats-nkey-pub", os.Getenv("NATS_PUB_NKEY"), "NATS NKey string for publishing")
+	jwtPub := flag.String("nats-jwt-pub", os.Getenv("NATS_PUB_JWT"), "NATS JWT string for publishing")
 	verbose := flag.Bool("verbose", false, "Verbose logs")
 
 	flag.Parse()

--- a/pkg/service/jetstream.go
+++ b/pkg/service/jetstream.go
@@ -35,7 +35,6 @@ func (b *Service) jsConsumerName(hash string) string {
 // Stream names must be explicit(no pattern matching) and must belong to only one stream.
 //
 // The interface for this feature is experimental and it should be expected to change.
-// It is possible to group a few subjects together
 //
 // NOTE: Messages are automatically acknowledged after handler returns.
 func (b *Service) AddStream(maxMsgs, maxBytes uint64, age time.Duration, subjects ...string) error {

--- a/pkg/service/jetstream.go
+++ b/pkg/service/jetstream.go
@@ -118,7 +118,6 @@ func (b *Service) RemoveStream(subjects ...string) error {
 
 	hash := b.jsMakeHash(subjects...)
 	streamName := b.jsStreamName(hash)
-	consumerName := b.jsConsumerName(hash)
 
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -126,11 +125,7 @@ func (b *Service) RemoveStream(subjects ...string) error {
 	ctx, cancel := context.WithTimeout(b.Context, 30*time.Second)
 	defer cancel()
 
-	err := b.js.DeleteConsumer(streamName, consumerName, nats.Context(ctx))
-	if err != nil {
-		return fmt.Errorf("DeleteConsumer failed: %w", err)
-	}
-	err = b.js.DeleteStream(streamName, nats.Context(ctx))
+	err := b.js.DeleteStream(streamName, nats.Context(ctx))
 	if err != nil {
 		return fmt.Errorf("DeleteStream failed: %w", err)
 	}

--- a/pkg/service/jetstream.go
+++ b/pkg/service/jetstream.go
@@ -1,0 +1,102 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+var ErrNotAvailable = fmt.Errorf("Not available")
+
+func (b *Service) jsStreamName(N int) string {
+	if N <= 0 {
+		N = len(b.streams) + 1
+	}
+	return fmt.Sprintf("%s-stream-%d", b.Name, N)
+}
+
+func (b *Service) jsConsumerName(N int) string {
+	return fmt.Sprintf("%s-%s", b.Identity, b.Name)
+}
+
+// AddStream is an experimental feature that creates JetStream stream and durable consumer.
+// The interface for this feature is experimental and is should be expected to change.
+//
+// Stream names must be explicit(no pattern matching) and must belong to only one stream.
+//
+// NOTE: Message Handler should manually acknowledge messages.
+func (b *Service) AddStream(maxMsgs, maxBytes uint64, age time.Duration, subjects ...string) error {
+	if b.js == nil {
+		return ErrNotAvailable
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for _, s := range subjects {
+		if strings.ContainsAny(s, ">*") {
+			return fmt.Errorf("%s unsupported", s)
+		}
+
+		if _, ok := b.streamSubjects[s]; ok {
+			return fmt.Errorf("%s already configured", s)
+		}
+	}
+
+	N := len(b.streams)
+	name := b.jsStreamName(N)
+
+	connCtx, connCancelFn := context.WithTimeout(b.Context, 10*time.Second)
+	defer connCancelFn()
+
+	cfg := &nats.StreamConfig{
+		Name:     name,
+		Subjects: subjects,
+		MaxMsgs:  int64(maxMsgs),
+		MaxBytes: int64(maxBytes),
+		MaxAge:   age,
+	}
+	si, err := b.js.AddStream(cfg, nats.Context(connCtx))
+	if err != nil {
+		return fmt.Errorf("AddStream failed: %w", err)
+	}
+
+	ci, err := b.js.AddConsumer(name, &nats.ConsumerConfig{
+		Durable: b.jsConsumerName(N),
+	})
+	if err != nil {
+		return fmt.Errorf("AddConsumer failed: %w", err)
+	}
+
+	b.streams = append(b.streams, jsStream{
+		cfg:          cfg,
+		streamInfo:   si,
+		consumerInfo: ci,
+	})
+
+	for _, s := range subjects {
+		b.streamSubjects[s] = N
+	}
+
+	return nil
+}
+
+func (b *Service) attemptJSConsume(handler nats.MsgHandler, subject string) (*nats.Subscription, error) {
+	if b.js == nil {
+		return nil, ErrNotAvailable
+	}
+
+	streamName, consumerName := "", ""
+	if id, ok := b.streamSubjects[subject]; !ok {
+		return nil, ErrNotAvailable
+	} else {
+		info := b.streams[id]
+		streamName = info.cfg.Name
+		consumerName = info.consumerInfo.Config.Durable
+	}
+
+	return b.js.Subscribe(subject, handler, nats.Bind(streamName, consumerName), nats.ManualAck())
+}

--- a/pkg/service/jetstream.go
+++ b/pkg/service/jetstream.go
@@ -2,7 +2,12 @@ package service
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
 	"fmt"
+	"log"
+	"slices"
 	"strings"
 	"time"
 
@@ -11,23 +16,25 @@ import (
 
 var ErrNotAvailable = fmt.Errorf("Not available")
 
-func (b *Service) jsStreamName(N int) string {
-	if N <= 0 {
-		N = len(b.streams) + 1
-	}
-	return fmt.Sprintf("%s-stream-%d", b.Name, N)
+func (b *Service) jsMakeHash(subjects ...string) string {
+	sum := sha256.Sum256([]byte(strings.Join(subjects, ",")))
+	return base64.RawStdEncoding.EncodeToString(sum[:])
 }
 
-func (b *Service) jsConsumerName(N int) string {
-	return fmt.Sprintf("%s-%s", b.Identity, b.Name)
+func (b *Service) jsStreamName(hash string) string {
+	return fmt.Sprintf("%s-stream-%s", b.Name, hash)
+}
+
+func (b *Service) jsConsumerName(hash string) string {
+	return fmt.Sprintf("%s-%s-%s", b.Identity, b.Name, hash)
 }
 
 // AddStream is an experimental feature that creates JetStream stream and durable consumer.
-// The interface for this feature is experimental and is should be expected to change.
+// The interface for this feature is experimental and it should be expected to change.
 //
 // Stream names must be explicit(no pattern matching) and must belong to only one stream.
 //
-// NOTE: Message Handler should manually acknowledge messages.
+// NOTE: Messages are automatically acknowledged after handler returns.
 func (b *Service) AddStream(maxMsgs, maxBytes uint64, age time.Duration, subjects ...string) error {
 	if b.js == nil {
 		return ErrNotAvailable
@@ -46,14 +53,14 @@ func (b *Service) AddStream(maxMsgs, maxBytes uint64, age time.Duration, subject
 		}
 	}
 
-	N := len(b.streams)
-	name := b.jsStreamName(N)
+	hash := b.jsMakeHash(subjects...)
+	streamName := b.jsStreamName(hash)
 
 	connCtx, connCancelFn := context.WithTimeout(b.Context, 10*time.Second)
 	defer connCancelFn()
 
 	cfg := &nats.StreamConfig{
-		Name:     name,
+		Name:     streamName,
 		Subjects: subjects,
 		MaxMsgs:  int64(maxMsgs),
 		MaxBytes: int64(maxBytes),
@@ -64,21 +71,65 @@ func (b *Service) AddStream(maxMsgs, maxBytes uint64, age time.Duration, subject
 		return fmt.Errorf("AddStream failed: %w", err)
 	}
 
-	ci, err := b.js.AddConsumer(name, &nats.ConsumerConfig{
-		Durable: b.jsConsumerName(N),
-	})
+	ccfg := &nats.ConsumerConfig{
+		Durable: b.jsConsumerName(hash),
+		// AckPolicy:     nats.AckExplicitPolicy,
+		DeliverPolicy: nats.DeliverAllPolicy,
+	}
+	ci, err := b.js.AddConsumer(streamName, ccfg)
+	if errors.Is(err, nats.ErrConsumerNameAlreadyInUse) {
+		ci, err = b.js.UpdateConsumer(streamName, ccfg)
+	}
 	if err != nil {
 		return fmt.Errorf("AddConsumer failed: %w", err)
 	}
 
 	b.streams = append(b.streams, jsStream{
-		cfg:          cfg,
+		cfgStream:    cfg,
+		cfgConsumer:  ccfg,
 		streamInfo:   si,
 		consumerInfo: ci,
 	})
 
 	for _, s := range subjects {
-		b.streamSubjects[s] = N
+		b.streamSubjects[s] = len(b.streams) - 1
+	}
+
+	return nil
+}
+
+// RemoveStream will attempt to remove consumers and streams based on a list of subjects.
+// List of subjects must be exactly the same as was used in AddStream since js Stream and js Consumer names
+// are based on the subjects.
+func (b *Service) RemoveStream(subjects ...string) error {
+	if b.js == nil {
+		return ErrNotAvailable
+	}
+
+	hash := b.jsMakeHash(subjects...)
+	streamName := b.jsStreamName(hash)
+	consumerName := b.jsConsumerName(hash)
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(b.Context, 30*time.Second)
+	defer cancel()
+
+	err := b.js.DeleteConsumer(streamName, consumerName, nats.Context(ctx))
+	if err != nil {
+		return fmt.Errorf("DeleteConsumer failed: %w", err)
+	}
+	err = b.js.DeleteStream(streamName, nats.Context(ctx))
+	if err != nil {
+		return fmt.Errorf("DeleteStream failed: %w", err)
+	}
+
+	for _, s := range subjects {
+		if ssIdx, ok := b.streamSubjects[s]; ok {
+			delete(b.streamSubjects, s)
+			b.streams = slices.Delete(b.streams, ssIdx, ssIdx)
+		}
 	}
 
 	return nil
@@ -89,14 +140,56 @@ func (b *Service) attemptJSConsume(handler nats.MsgHandler, subject string) (*na
 		return nil, ErrNotAvailable
 	}
 
+	var info jsStream
 	streamName, consumerName := "", ""
 	if id, ok := b.streamSubjects[subject]; !ok {
 		return nil, ErrNotAvailable
 	} else {
-		info := b.streams[id]
-		streamName = info.cfg.Name
+		info = b.streams[id]
+		streamName = info.cfgStream.Name
 		consumerName = info.consumerInfo.Config.Durable
 	}
 
-	return b.js.Subscribe(subject, handler, nats.Bind(streamName, consumerName), nats.ManualAck())
+	sub, err := b.js.PullSubscribe(streamName, consumerName, nats.ManualAck(), nats.Bind(streamName, consumerName))
+	if err != nil {
+		return nil, err
+	}
+
+	b.Group.Go(func() error {
+		log.Println("PullSubscribe loop start: ", subject)
+		defer log.Println("PullSubscribe loop exit: ", subject)
+		for {
+			select {
+			case <-b.Context.Done():
+				return b.Context.Err()
+			default:
+			}
+
+			ctx, cancel := context.WithTimeout(b.Context, 5*time.Second)
+			defer cancel()
+
+			msgs, err := sub.Fetch(10, nats.Context(ctx))
+			if err != nil {
+				if errors.Is(err, context.Canceled) {
+					return fmt.Errorf("context cancelled during pulling next message: %w", err)
+				}
+				if errors.Is(err, context.DeadlineExceeded) {
+					continue
+				}
+				if errors.Is(err, nats.ErrBadSubscription) {
+					log.Printf("Subscription to %s closed", subject)
+					return nil
+				}
+				return fmt.Errorf("Error during pulling next message: %w", err)
+			}
+			for _, msg := range msgs {
+				handler(msg)
+				if err := msg.Ack(); err != nil {
+					log.Println("Error during message ack: ", err)
+				}
+			}
+		}
+	})
+
+	return sub, nil
 }

--- a/pkg/service/jetstream.go
+++ b/pkg/service/jetstream.go
@@ -32,7 +32,6 @@ func (b *Service) jsConsumerName(hash string) string {
 // AddStream is an experimental feature that creates a durable stream. It is possible to
 // subscribe to this durable stream using regular Subscribe or SubscribeTo methods given that
 // the subject is included in the created stream.
-// Stream names must be explicit(no pattern matching) and must belong to only one stream.
 //
 // The interface for this feature is experimental and it should be expected to change.
 //

--- a/pkg/service/options.go
+++ b/pkg/service/options.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/cosmos/btcutil/base58"
-	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"
 	"github.com/syntropynet/data-layer-sdk/pkg/options"
 )
@@ -34,18 +33,15 @@ func WithContext(ctx context.Context) options.Option {
 }
 
 // WithNats sets up preconfigured NATS connector for publishing and subscribing.
-func WithNats(nc *nats.Conn) options.Option {
+func WithNats(nc options.NatsConn) options.Option {
 	return func(o *options.Options) {
-		if nc == nil {
-			return
-		}
-		o.PubNats = nc
-		o.SubNats = nc
+		WithPubNats(nc)(o)
+		WithSubNats(nc)(o)
 	}
 }
 
 // WithPubNats sets up preconfigured NATS connector specifically for publishing.
-func WithPubNats(nc *nats.Conn) options.Option {
+func WithPubNats(nc options.NatsConn) options.Option {
 	return func(o *options.Options) {
 		if nc == nil {
 			return
@@ -55,7 +51,7 @@ func WithPubNats(nc *nats.Conn) options.Option {
 }
 
 // WithSubNats sets up preconfigured NATS connector speficivally for subscribing.
-func WithSubNats(nc *nats.Conn) options.Option {
+func WithSubNats(nc options.NatsConn) options.Option {
 	return func(o *options.Options) {
 		if nc == nil {
 			return

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -32,7 +32,8 @@ type JetStreamer interface {
 var _ JetStreamer = &nats.Conn{}
 
 type jsStream struct {
-	cfg          *nats.StreamConfig
+	cfgStream    *nats.StreamConfig
+	cfgConsumer  *nats.ConsumerConfig
 	streamInfo   *nats.StreamInfo
 	consumerInfo *nats.ConsumerInfo
 }
@@ -86,7 +87,8 @@ func (b *Service) Configure(opts ...options.Option) error {
 	}
 
 	if js, ok := b.SubNats.(JetStreamer); ok {
-		b.js, err = js.JetStream()
+		b.js, err = js.JetStream(nats.Context(b.Context))
+		b.streamSubjects = make(map[string]int)
 	}
 	return nil
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -25,6 +25,18 @@ import (
 // "uptime", "goroutines", "period" keys will be overriden internally.
 type StatusFunc func() map[string]any
 
+type JetStreamer interface {
+	JetStream(opts ...nats.JSOpt) (nats.JetStreamContext, error)
+}
+
+var _ JetStreamer = &nats.Conn{}
+
+type jsStream struct {
+	cfg          *nats.StreamConfig
+	streamInfo   *nats.StreamInfo
+	consumerInfo *nats.ConsumerInfo
+}
+
 // Service is the base publisher structure. It must be embedded in the publisher to benefit from the
 // common implementation. Config method must be called on this embedded struct in order to
 // properly set it up.
@@ -40,6 +52,11 @@ type Service struct {
 	bytes_in_counter  atomic.Uint64
 	bytes_out_counter atomic.Uint64
 	statusCallback    map[uintptr]StatusFunc
+
+	// Experimental feature
+	js             nats.JetStreamContext
+	streams        []jsStream
+	streamSubjects map[string]int
 }
 
 // Configure must be called by the publisher implementation.
@@ -63,6 +80,14 @@ func (b *Service) Configure(opts ...options.Option) error {
 	}
 	b.Identity = base58.Encode(pubkey)
 	log.Println("Identity: ", b.Identity)
+
+	if b.SubNats == nil {
+		return nil
+	}
+
+	if js, ok := b.SubNats.(JetStreamer); ok {
+		b.js, err = js.JetStream()
+	}
 	return nil
 }
 
@@ -158,6 +183,8 @@ func (b *Service) Subscribe(handler MessageHandler, suffixes ...string) (*nats.S
 
 // SubscribeTo will subscribe to a subject constructed {...suffixes}, where
 // suffixes are joined using ".".
+//
+// Experimental: When a stream was registered with AddStream SubscribeTo will use durable stream instead of realtime.
 func (b *Service) SubscribeTo(handler MessageHandler, suffixes ...string) (*nats.Subscription, error) {
 	if b.SubNats == nil {
 		return nil, fmt.Errorf("subscribing NATS connection is nil")
@@ -172,10 +199,16 @@ func (b *Service) SubscribeTo(handler MessageHandler, suffixes ...string) (*nats
 		handler(wrapped)
 	}
 
-	if b.QueueName != "" {
-		return b.SubNats.QueueSubscribe(strings.Join(suffixes, "."), b.QueueName, natsHandler)
+	subject := strings.Join(suffixes, ".")
+
+	if sub, err := b.attemptJSConsume(natsHandler, subject); err == nil {
+		return sub, nil
 	}
-	return b.SubNats.Subscribe(strings.Join(suffixes, "."), natsHandler)
+
+	if b.QueueName != "" {
+		return b.SubNats.QueueSubscribe(subject, b.QueueName, natsHandler)
+	}
+	return b.SubNats.Subscribe(subject, natsHandler)
 }
 
 // Close should be closed to clean-up the publisher.

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -57,7 +57,7 @@ type Service struct {
 	// Experimental feature
 	js             nats.JetStreamContext
 	streams        []jsStream
-	streamSubjects map[string]int
+	streamSubjects SubjectMap
 }
 
 // Configure must be called by the publisher implementation.
@@ -88,7 +88,11 @@ func (b *Service) Configure(opts ...options.Option) error {
 
 	if js, ok := b.SubNats.(JetStreamer); ok {
 		b.js, err = js.JetStream(nats.Context(b.Context))
-		b.streamSubjects = make(map[string]int)
+		if err != nil {
+			log.Printf("JetStream failed: %v", err)
+			return nil
+		}
+		b.streamSubjects = make(SubjectMap)
 	}
 	return nil
 }

--- a/pkg/service/subject.go
+++ b/pkg/service/subject.go
@@ -1,0 +1,98 @@
+package service
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Subject represents a NATS subject which can include wildcards.
+type Subject string
+
+// String converts the Subject back to its string representation.
+func (s Subject) String() string {
+	return string(s)
+}
+
+// Tokens splits the Subject into its constituent parts, divided by '.'.
+func (s Subject) Tokens() []string {
+	return strings.Split(string(s), ".")
+}
+
+// Validate checks if the Subject contains any characters that are not allowed.
+func (s Subject) Validate() error {
+	if strings.ContainsAny(s.String(), ",? \r\n\t$\b") {
+		return fmt.Errorf("invalid subject: %s", s.String())
+	}
+	return nil
+}
+
+// Match tries to pattern-match the subject against another subject.
+// It considers NATS wildcard rules where '*' matches any token at a level, and '>' matches all subsequent tokens.
+func (s Subject) Match(subject Subject) bool {
+	pTokens := s.Tokens()
+	sTokens := subject.Tokens()
+
+	for i, pToken := range pTokens {
+		if pToken == ">" {
+			return true
+		}
+		if i >= len(sTokens) {
+			return false
+		}
+		if pToken != "*" && pToken != sTokens[i] {
+			return false
+		}
+	}
+
+	return len(pTokens) == len(sTokens) || pTokens[len(pTokens)-1] == "*"
+}
+
+// SymmetricMatch tries to pattern-match a subject against another subject in both directions.
+// It considers a match if either subject matches the other according to NATS wildcard rules.
+func (s Subject) SymmetricMatch(subject Subject) bool {
+	return s.Match(subject) || subject.Match(s)
+}
+
+// SubjectMap maps subjects (as strings) to indices to an array that holds stream and consumer configs.
+type SubjectMap map[Subject]int
+
+// Add inserts a subject and its associated index into the map.
+// It returns an error if the subject is invalid, but in the current implementation, it always succeeds.
+func (m SubjectMap) Add(subject Subject, idx int) error {
+	if err := subject.Validate(); err != nil {
+		return err
+	}
+	m[subject] = idx
+	return nil
+}
+
+// Search looks for a subject in the map that matches the given subject according to NATS pattern matching rules.
+// Returns the matching subject, its associated index, and true if a match is found.
+// If no match is found, it returns empty string, 0, and false.
+func (m SubjectMap) Search(subject Subject) (Subject, int, bool) {
+	for k, v := range m {
+		if k.Match(subject) {
+			return k, v, true
+		}
+	}
+	return "", 0, false
+}
+
+// Get returns the index stored
+func (m SubjectMap) Get(subject Subject) (int, bool) {
+	v, ok := m[subject]
+	return v, ok
+}
+
+// SymmetricSearch looks for a subject in the map that symmetrically matches the given subject.
+// Symmetric matching means either the map's subject matches the given subject or vice versa.
+// Returns the matching subject, its associated index, and true if a match is found.
+// If no match is found, it returns empty string, 0, and false.
+func (m SubjectMap) SymmetricSearch(subject Subject) (Subject, int, bool) {
+	for k, v := range m {
+		if k.SymmetricMatch(subject) {
+			return k, v, true
+		}
+	}
+	return "", 0, false
+}

--- a/pkg/service/subject.go
+++ b/pkg/service/subject.go
@@ -23,6 +23,11 @@ func (s Subject) Validate() error {
 	if strings.ContainsAny(s.String(), ",? \r\n\t$\b") {
 		return fmt.Errorf("invalid subject: %s", s.String())
 	}
+	for _, token := range s.Tokens() {
+		if token == "" {
+			return fmt.Errorf("empty token: %s", s.String())
+		}
+	}
 	return nil
 }
 
@@ -44,7 +49,7 @@ func (s Subject) Match(subject Subject) bool {
 		}
 	}
 
-	return len(pTokens) == len(sTokens) || pTokens[len(pTokens)-1] == "*"
+	return len(pTokens) == len(sTokens)
 }
 
 // SymmetricMatch tries to pattern-match a subject against another subject in both directions.

--- a/pkg/service/subject_test.go
+++ b/pkg/service/subject_test.go
@@ -22,6 +22,7 @@ func TestSubject_Validate(t *testing.T) {
 	}{
 		{"good", Subject("a.*.c.>"), false},
 		{"bad?", Subject("a.?"), true},
+		{"empty token", Subject("a."), true},
 		{"bad,", Subject("a.,s"), true},
 		{"bad whitespace", Subject("hellow world"), true},
 		{"bad whitespace1", Subject("hellow. world"), true},
@@ -44,9 +45,14 @@ func TestSubject_Match(t *testing.T) {
 		subject Subject
 		want    bool
 	}{
+		{"longer", Subject("a.b"), Subject("a.b.c"), false},
+		{"shorter", Subject("a.b"), Subject("a"), false},
+		{"shorter *", Subject("a.b.*"), Subject("a.b"), false},
+		{"even longer", Subject("a.b.*"), Subject("a.b.c.d"), false},
 		{"exact", Subject("a.b"), Subject("a.b"), true},
 		{"false", Subject("a.b"), Subject("a.c"), false},
 		{"all exact", Subject("a.b.>"), Subject("a.b.>"), true},
+		{"all longer", Subject("a.b.>"), Subject("a.b.c.d.e"), true},
 		{"all subj reverse", Subject("a.b.c"), Subject("a.b.>"), false},
 		{"all almost reverse", Subject("a.b.*"), Subject("a.b.>"), true}, // NOTE: This is a weird case
 		{"all almost", Subject("a.b.>"), Subject("a.b.*"), true},

--- a/pkg/service/subject_test.go
+++ b/pkg/service/subject_test.go
@@ -1,0 +1,92 @@
+package service
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSubject_Tokens(t *testing.T) {
+	tokens := Subject("a.b.c.>").Tokens()
+	want := []string{"a", "b", "c", ">"}
+
+	if !reflect.DeepEqual(tokens, want) {
+		t.Errorf("Subject.Tokens() = %v, want %v", tokens, want)
+	}
+}
+
+func TestSubject_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		s       Subject
+		wantErr bool
+	}{
+		{"good", Subject("a.*.c.>"), false},
+		{"bad?", Subject("a.?"), true},
+		{"bad,", Subject("a.,s"), true},
+		{"bad whitespace", Subject("hellow world"), true},
+		{"bad whitespace1", Subject("hellow. world"), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.s.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Subject.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSubject_Match(t *testing.T) {
+	type args struct {
+	}
+	tests := []struct {
+		name    string
+		pattern Subject
+		subject Subject
+		want    bool
+	}{
+		{"exact", Subject("a.b"), Subject("a.b"), true},
+		{"false", Subject("a.b"), Subject("a.c"), false},
+		{"all exact", Subject("a.b.>"), Subject("a.b.>"), true},
+		{"all subj reverse", Subject("a.b.c"), Subject("a.b.>"), false},
+		{"all almost reverse", Subject("a.b.*"), Subject("a.b.>"), true}, // NOTE: This is a weird case
+		{"all almost", Subject("a.b.>"), Subject("a.b.*"), true},
+		{"all specific", Subject("a.b.>"), Subject("a.b.c"), true},
+		{"middle reverse", Subject("a.b.c"), Subject("a.*.c"), false},
+		{"middle1", Subject("a.*.c"), Subject("a.b.c"), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.pattern.Match(tt.subject); got != tt.want {
+				t.Errorf("Subject.Match() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSubject_SymmetricMatch(t *testing.T) {
+	type args struct {
+	}
+	tests := []struct {
+		name    string
+		pattern Subject
+		subject Subject
+		want    bool
+	}{
+		{"exact", Subject("a.b"), Subject("a.b"), true},
+		{"false", Subject("a.b"), Subject("a.c"), false},
+		{"all exact", Subject("a.b.>"), Subject("a.b.>"), true},
+		{"all subj reverse", Subject("a.b.c"), Subject("a.b.>"), true},
+		{"all almost", Subject("a.b.>"), Subject("a.b.*"), true},
+		{"all almost reverse", Subject("a.b.*"), Subject("a.b.>"), true}, // NOTE: This is a weird case
+		{"all specific", Subject("a.b.>"), Subject("a.b.c"), true},
+		{"middle reverse", Subject("a.b.c"), Subject("a.*.c"), true},
+		{"middle1", Subject("a.*.c"), Subject("a.b.c"), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.pattern.SymmetricMatch(tt.subject); got != tt.want {
+				t.Errorf("SymmetricSubject.Match() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
This PR introduces experimental JetStream support.

The basic usage is to register a list of specific subjects a developer wants to enable durable stream and then to subscribe as usual.
The subscription will use a consumer and retrieve all messages that were not acknowledged yet.

Consumer name uses identity and the name of the service. Hash of the list of all subjects is also used, therefore, consumers are created per list of subjects individually for each service that has unique identity.

## Related Issue
Closes #2

## Proposed Changes
- `AddStream` method
- `RemoveStream` method
- `durable` example
- Options accept interface instead of concrete NATS instance

## Additional Info
This is an experimental feature. The API might change in the future or removed all together. Therefore it is not documented.
