### PR TITLE
4 refactor logging

### DIFF
--- a/examples/durable/main.go
+++ b/examples/durable/main.go
@@ -3,7 +3,8 @@ package main
 import (
 	"context"
 	"flag"
-	"log"
+	"fmt"
+	"log/slog"
 	"os"
 	"os/signal"
 
@@ -25,7 +26,7 @@ func main() {
 
 	conn, err := options.MakeNats("Streaming consumer", *urls, *creds, *nkey, *jwt, "", "", "")
 	if err != nil {
-		log.Fatal("Failed creating NATS connection: ", err.Error())
+		panic(fmt.Errorf("Failed creating NATS connection: %w", err))
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
@@ -47,7 +48,7 @@ func main() {
 
 	publisher, err := New(opts...)
 	if err != nil {
-		log.Fatal("Failed creating the consumer: ", err.Error())
+		panic(fmt.Errorf("Failed creating the consumer: %w", err))
 	}
 
 	pubCtx := publisher.Start()
@@ -55,8 +56,8 @@ func main() {
 
 	select {
 	case <-ctx.Done():
-		log.Println("Shutdown")
+		slog.Info("Shutdown")
 	case <-pubCtx.Done():
-		log.Println("Service stopped with cause: ", context.Cause(pubCtx).Error())
+		slog.Info("Publisher stopped", "cause", context.Cause(pubCtx).Error())
 	}
 }

--- a/examples/republish/main.go
+++ b/examples/republish/main.go
@@ -3,7 +3,8 @@ package main
 import (
 	"context"
 	"flag"
-	"log"
+	"fmt"
+	"log/slog"
 	"os"
 	"os/signal"
 
@@ -29,7 +30,7 @@ func main() {
 
 	conn, err := options.MakeNats("Republish Publisher", *urls, *creds, *nkey, *jwt, "", "", "")
 	if err != nil {
-		log.Fatal("Failed creating NATS connection: ", err.Error())
+		panic(fmt.Errorf("Failed creating NATS connection: %w", err))
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
@@ -47,7 +48,7 @@ func main() {
 	if *credsPub != "" || *nkeyPub != "" || *jwtPub != "" {
 		conn, err := options.MakeNats("Republish Publisher", *urls, *credsPub, *nkeyPub, *jwtPub, "", "", "")
 		if err != nil {
-			log.Fatal("Failed creating publishing NATS connection: ", err.Error())
+			panic(fmt.Errorf("Failed creating publishing NATS connection: %w", err))
 		}
 
 		// NOTE: Using publisher's side credentials for identity.
@@ -69,7 +70,7 @@ func main() {
 
 	publisher, err := New(opts...)
 	if err != nil {
-		log.Fatal("Failed creating the republisher: ", err.Error())
+		panic(fmt.Errorf("Failed creating the republisher: %w", err))
 	}
 
 	pubCtx := publisher.Start()
@@ -77,8 +78,8 @@ func main() {
 
 	select {
 	case <-ctx.Done():
-		log.Println("Shutdown")
+		slog.Info("Shutdown")
 	case <-pubCtx.Done():
-		log.Println("Publisher stopped with cause: ", context.Cause(pubCtx).Error())
+		slog.Info("Publisher stopped", "cause", context.Cause(pubCtx).Error())
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/syntropynet/data-layer-sdk
 
-go 1.20
+go 1.21
 
 require (
 	github.com/cosmos/btcutil v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,7 @@ github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwA
 github.com/klauspost/compress v1.16.5 h1:IFV2oUNUzZaz+XyusxpLzpzS8Pt5rh0Z16For/djlyI=
 github.com/klauspost/compress v1.16.5/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA/g=
+github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/nats-io/jwt/v2 v2.4.1 h1:Y35W1dgbbz2SQUYDPCaclXcuqleVmpbRa7646Jf2EX4=
 github.com/nats-io/jwt/v2 v2.4.1/go.mod h1:24BeQtRwxRV8ruvC4CojXlx/WQ/VjuwlYiH+vu/+ibI=
 github.com/nats-io/nats-server/v2 v2.9.15 h1:MuwEJheIwpvFgqvbs20W8Ish2azcygjf4Z0liVu2I4c=
@@ -26,6 +27,7 @@ golang.org/x/sync v0.4.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/time v0.3.0 h1:rg5rLMjNzMS1RkNLzCG38eapWhnYLFYXDXj2gOlr8j4=
+golang.org/x/time v0.3.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=

--- a/pkg/dotenv/dotenv.go
+++ b/pkg/dotenv/dotenv.go
@@ -3,7 +3,7 @@ package dotenv
 
 import (
 	"errors"
-	"log"
+	"log/slog"
 	"os"
 
 	"github.com/joho/godotenv"
@@ -11,8 +11,8 @@ import (
 
 func init() {
 	if err := godotenv.Load(); err == nil {
-		log.Println(".env file detected.")
+		slog.Info(".env file detected.")
 	} else if !errors.Is(err, os.ErrNotExist) {
-		log.Println(".env file failed: ", err.Error())
+		slog.Warn(".env file failed: ", err)
 	}
 }

--- a/pkg/options/nats.go
+++ b/pkg/options/nats.go
@@ -2,7 +2,7 @@ package options
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 
 	"github.com/nats-io/nats.go"
 )
@@ -10,7 +10,7 @@ import (
 // MakeNats is a convenience function to create NATS connection from various parameters.
 func MakeNats(name, urls, userCreds, nkey, jwt, caCert, clientCert, clientKey string) (*nats.Conn, error) {
 	if urls == "" {
-		log.Println("Will use NATS stub")
+		slog.Info("Will use NATS stub")
 		return nil, nil
 	}
 

--- a/pkg/options/nats.stub.go
+++ b/pkg/options/nats.stub.go
@@ -2,20 +2,21 @@ package options
 
 import (
 	"context"
-	"log"
+	"log/slog"
 
 	"github.com/nats-io/nats.go"
 )
 
 type natsStub struct {
 	Verbose *bool
+	logger  *slog.Logger
 }
 
 func (s *natsStub) Subscribe(subj string, cb nats.MsgHandler) (*nats.Subscription, error) {
 	if !*s.Verbose {
 		return nil, nil
 	}
-	log.Println("NATS: subscribing to subj=", subj)
+	s.logger.Debug("NATS: subscribing to", "subj", subj)
 	return nil, nil
 }
 
@@ -23,7 +24,7 @@ func (s *natsStub) QueueSubscribe(subj, queue string, cb nats.MsgHandler) (*nats
 	if !*s.Verbose {
 		return nil, nil
 	}
-	log.Println("NATS: subscribing to subj=", subj, "queue=", queue)
+	s.logger.Debug("NATS: subscribing to", "subj", subj, "queue", queue)
 	return nil, nil
 }
 
@@ -31,7 +32,7 @@ func (s *natsStub) RequestMsgWithContext(ctx context.Context, m *nats.Msg) (*nat
 	if !*s.Verbose {
 		return m, nil
 	}
-	log.Println("NATS: req subj=", m.Subject, " len(data)=", len(m.Data), " data=", string(m.Data))
+	s.logger.Debug("NATS: req ", "subj", m.Subject, "len(data)", len(m.Data), "data", string(m.Data))
 	return m, nil
 }
 
@@ -39,7 +40,7 @@ func (s *natsStub) PublishMsg(m *nats.Msg) error {
 	if !*s.Verbose {
 		return nil
 	}
-	log.Println("NATS: pub subj=", m.Subject, " len(data)=", len(m.Data), " data=", string(m.Data))
+	s.logger.Debug("NATS: pub", "subj", m.Subject, "len(data)", len(m.Data), "data", string(m.Data))
 	return nil
 }
 

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -6,7 +6,8 @@ import (
 	"crypto"
 	"crypto/ed25519"
 	"errors"
-	"log"
+	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -54,6 +55,7 @@ type Options struct {
 
 	// Include verbose logging
 	VerboseLog bool
+	Logger     *slog.Logger
 	// Determines how often to send telemetry messages.
 	TelemetryPeriod time.Duration
 
@@ -93,11 +95,12 @@ type Options struct {
 func (o *Options) setDefaults() {
 	_, pkey, err := ed25519.GenerateKey(nil)
 	if err != nil {
-		log.Fatal(err)
+		panic(fmt.Errorf("failed generating ed25519 key: %w", err))
 	}
+	o.Logger = slog.Default()
 	o.SetContext(context.Background())
-	o.PubNats = &natsStub{Verbose: &o.VerboseLog}
-	o.SubNats = &natsStub{Verbose: &o.VerboseLog}
+	o.PubNats = &natsStub{Verbose: &o.VerboseLog, logger: o.Logger}
+	o.SubNats = &natsStub{Verbose: &o.VerboseLog, logger: o.Logger}
 	o.PrivateKey = pkey
 	o.Prefix = "syntropy"
 	o.Name = "rnd"

--- a/pkg/service/jetstream.go
+++ b/pkg/service/jetstream.go
@@ -3,13 +3,13 @@ package service
 import (
 	"context"
 	"crypto/sha256"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"slices"
 	"strings"
 	"time"
 
+	"github.com/cosmos/btcutil/base58"
 	"github.com/nats-io/nats.go"
 )
 
@@ -17,7 +17,7 @@ var ErrNotAvailable = fmt.Errorf("not available")
 
 func (b *Service) jsMakeHash(subjects ...string) string {
 	sum := sha256.Sum256([]byte(strings.Join(subjects, ",")))
-	return base64.RawStdEncoding.EncodeToString(sum[:])
+	return base58.Encode(sum[:])
 }
 
 func (b *Service) jsStreamName(hash string) string {

--- a/pkg/service/options.go
+++ b/pkg/service/options.go
@@ -29,6 +29,9 @@ func WithParam(key string, val any) options.Option {
 // WithLogger sets the logger for the publisher.
 func WithLogger(logger *slog.Logger) options.Option {
 	return func(o *options.Options) {
+		if logger == nil {
+			panic(errors.New("logger must not be nil"))
+		}
 		o.Logger = logger
 	}
 }

--- a/pkg/service/telemetry.go
+++ b/pkg/service/telemetry.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"log"
 	"strconv"
 	"time"
 )
@@ -11,13 +10,13 @@ func (b *Service) handleTelemetryPing(nmsg Message) {
 	var ping TelemetryPing
 	_, err := b.Unmarshal(nmsg, &ping)
 	if err != nil {
-		log.Println("ERR: ping: ", err.Error())
+		b.Logger.Error("ping", err)
 		return
 	}
 
 	timestamp, err := strconv.ParseInt(ping.Timestamp, 10, 64)
 	if err != nil {
-		log.Println("ERR: not a number in timestamp")
+		b.Logger.Error("not a number in timestamp", err)
 		return
 	}
 


### PR DESCRIPTION
## Description
This change refactors data-layer-sdk to use `slog.Logger` for logging facilities.

## Related Issue
Closes #4 in such a way so that it would be possible to:
- configure logging aggregators/alerts to effectively parse structured logs
- configure logging level

## Proposed Changes
- bump minimum Go version to v1.21 to make `slog` available
- refactor logging to use `Logger` that can be configured using `WithLogger`
- Emergency fix to encode JetStream name to base58 instead of base64. Some base64 characters are not allowed by NATS.
