### PR TITLE
fix: jsStreamName does not depend on identity. add: allow setting Jet…

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -82,6 +82,8 @@ type Options struct {
 	Prefix string
 	// Name of the NATS queue
 	QueueName string
+	// Name of JetStream stream. If an empty string is used, then stream name will be "{prefix}-{name}"
+	StreamName string
 	// Name of the publisher
 	Name string
 	// Codec is used to marshal published messages to whire format.

--- a/pkg/service/jetstream.go
+++ b/pkg/service/jetstream.go
@@ -29,7 +29,7 @@ func (b *Service) jsStreamName() string {
 }
 
 func (b *Service) jsConsumerName(hash string) string {
-	return fmt.Sprintf("%s-%s-%s", b.Identity, b.Name, hash)
+	return fmt.Sprintf("%s-%s", b.Identity, hash)
 }
 
 // AddStream is an experimental feature that creates a durable stream. It is possible to

--- a/pkg/service/jetstream.go
+++ b/pkg/service/jetstream.go
@@ -38,6 +38,11 @@ func (b *Service) jsConsumerName(hash string) string {
 //
 // The interface for this feature is experimental and it should be expected to change.
 //
+// This method will create a stream with maxMsgs, maxBytes, and age for a list of subjects on JetStream if it does not exist.
+// This is a temporary solution so that the stream doesn't have to be created manually. However,
+// this will change in the near future, therefore users will have to make sure that the stream exists
+// before calling this method(maxMsgs, maxBytes, and age parameters will be removed).
+//
 // NOTE: Messages are automatically acknowledged after handler returns.
 func (b *Service) AddStream(maxMsgs, maxBytes uint64, age time.Duration, subjects ...string) error {
 	if b.js == nil {

--- a/pkg/service/jetstream.go
+++ b/pkg/service/jetstream.go
@@ -110,8 +110,8 @@ func (b *Service) AddStream(maxMsgs, maxBytes uint64, age time.Duration, subject
 	return nil
 }
 
-// RemoveStream will attempt to remove consumers and streams based on a list of subjects.
-// List of subjects must be exactly the same as was used in AddStream since js Stream and js Consumer names
+// RemoveStream will attempt to remove consumers based on a list of subjects.
+// List of subjects must be exactly the same as was used in AddStream since js Consumer names
 // are based on the subjects.
 func (b *Service) RemoveStream(subjects ...string) error {
 	if b.js == nil {
@@ -119,7 +119,8 @@ func (b *Service) RemoveStream(subjects ...string) error {
 	}
 
 	hash := b.jsMakeHash(subjects...)
-	streamName := b.jsConsumerName(hash)
+	streamName := b.jsStreamName()
+	consumerName := b.jsConsumerName(hash)
 
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -127,9 +128,9 @@ func (b *Service) RemoveStream(subjects ...string) error {
 	ctx, cancel := context.WithTimeout(b.Context, 30*time.Second)
 	defer cancel()
 
-	err := b.js.DeleteStream(streamName, nats.Context(ctx))
+	err := b.js.DeleteConsumer(streamName, consumerName, nats.Context(ctx))
 	if err != nil {
-		return fmt.Errorf("DeleteStream failed: %w", err)
+		return fmt.Errorf("DeleteConsumer failed: %w", err)
 	}
 
 	b.removeStreamsFromMap(subjects)

--- a/pkg/service/options.go
+++ b/pkg/service/options.go
@@ -82,6 +82,14 @@ func WithName(name string) options.Option {
 	}
 }
 
+// WithStreamName sets name of the JetStream stream.
+// If an empty string is used, then stream name will be "{prefix}-{name}".
+func WithStreamName(name string) options.Option {
+	return func(o *options.Options) {
+		o.StreamName = name
+	}
+}
+
 // WithPrefix sets the prefix for the subject. The subject is in the form of {prefix}.{name}.
 // Subscriptions and publishing will use the subject constructed from prefix and name.
 func WithPrefix(prefix string) options.Option {


### PR DESCRIPTION
Configure JetSream Stream name via options.

## Description
Remove coupling between publisher identity and JetStream Stream name. Stream should be managed outside of the users of `data-layer-sdk` anyway.

## Related Issue
Closes #6
