### PR TITLE
Fix/nil check

### DIFF
--- a/pkg/service/options.go
+++ b/pkg/service/options.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"reflect"
 	"strings"
 	"time"
 
@@ -55,7 +56,7 @@ func WithNats(nc options.NatsConn) options.Option {
 // WithPubNats sets up preconfigured NATS connector specifically for publishing.
 func WithPubNats(nc options.NatsConn) options.Option {
 	return func(o *options.Options) {
-		if nc == nil {
+		if reflect.ValueOf(nc).IsNil() {
 			return
 		}
 		o.PubNats = nc
@@ -67,7 +68,7 @@ func WithPubNats(nc options.NatsConn) options.Option {
 // NOTE: This will also set ReqNats for compatibility.
 func WithSubNats(nc options.NatsConn) options.Option {
 	return func(o *options.Options) {
-		if nc == nil {
+		if reflect.ValueOf(nc).IsNil() {
 			return
 		}
 		o.SubNats = nc
@@ -78,7 +79,7 @@ func WithSubNats(nc options.NatsConn) options.Option {
 // WithReqNats sets up preconfigured NATS connector specifically for request/reply.
 func WithReqNats(nc options.NatsConn) options.Option {
 	return func(o *options.Options) {
-		if nc == nil {
+		if reflect.ValueOf(nc).IsNil() {
 			return
 		}
 		o.ReqNats = nc

--- a/pkg/service/options.go
+++ b/pkg/service/options.go
@@ -56,7 +56,7 @@ func WithNats(nc options.NatsConn) options.Option {
 // WithPubNats sets up preconfigured NATS connector specifically for publishing.
 func WithPubNats(nc options.NatsConn) options.Option {
 	return func(o *options.Options) {
-		if reflect.ValueOf(nc).IsNil() {
+		if nc == nil || reflect.ValueOf(nc).IsNil() {
 			return
 		}
 		o.PubNats = nc
@@ -68,7 +68,7 @@ func WithPubNats(nc options.NatsConn) options.Option {
 // NOTE: This will also set ReqNats for compatibility.
 func WithSubNats(nc options.NatsConn) options.Option {
 	return func(o *options.Options) {
-		if reflect.ValueOf(nc).IsNil() {
+		if nc == nil || reflect.ValueOf(nc).IsNil() {
 			return
 		}
 		o.SubNats = nc
@@ -79,7 +79,7 @@ func WithSubNats(nc options.NatsConn) options.Option {
 // WithReqNats sets up preconfigured NATS connector specifically for request/reply.
 func WithReqNats(nc options.NatsConn) options.Option {
 	return func(o *options.Options) {
-		if reflect.ValueOf(nc).IsNil() {
+		if nc == nil || reflect.ValueOf(nc).IsNil() {
 			return
 		}
 		o.ReqNats = nc

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -110,6 +110,7 @@ func (b *Service) Configure(opts ...options.Option) error {
 func (b *Service) run() error {
 	sub, err := b.Subscribe(b.handleTelemetryPing, "telemetry", "ping")
 	if err != nil {
+		err = fmt.Errorf("Telemetry subscription failed: %w", err)
 		b.Cancel(err)
 		return err
 	}


### PR DESCRIPTION
## Description
When `stub` together with `WithNats` error is thrown:
```
2024/05/30 15:48:02 INFO .env file detected.
INFO Will use NATS stub
INFO Service configured identity=DXuHSUtc9ni2aVdJ5qThDqrVpbxUosfwjJmw1mASSNX1 JetStream=true
Publisher stopped with cause:  nats: invalid connection <--- ERRROR
Starting...
Publisher.Close
Waiting on publisher group
Publisher.Close DONE
```

```
WithPubNats
WithSubNats
WithReqNats
```
have nil check, but nil checks interface, not underlying value for nil. 
Reflection should be used, see: https://glucn.com/posts/2019-05-20-golang-an-interface-holding-a-nil-value-is-not-nil